### PR TITLE
wettelijke documenten excluden van pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_install_hook_types:
 
 # default_stages: [commit]
 
-exclude: (docs|template)
+exclude: (wettelijke-documenten)
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.


### PR DESCRIPTION
Tabellen in .txt worden onduidelijk door pre-commit hooks die whitespace etc deleten