### PR TITLE
Uitbreiding referentiedata

### DIFF
--- a/scripts/genereer_vera_referentiedata.py
+++ b/scripts/genereer_vera_referentiedata.py
@@ -34,13 +34,26 @@ source_data.fieldnames = (
     else None
 )
 
+
+filename = "woningwaardering/vera/referentiedata_uitbreiding.csv"
+with open(filename, "r", encoding="utf-8") as file:
+    uitbreiding_data = csv.DictReader(file.readlines(), delimiter=";")
+    uitbreiding_data.fieldnames = (
+        [name.lower() for name in uitbreiding_data.fieldnames]
+        if uitbreiding_data.fieldnames
+        else None
+    )
+
 # Filter out items with a past einddatum
-active_data = [
-    item
-    for item in source_data
-    if (not item["einddatum"])
-    or (datetime.strptime(item["einddatum"], "%d-%m-%Y").date() >= date.today())
-]
+active_data = sorted(
+    [
+        item
+        for item in list(source_data) + list(uitbreiding_data)
+        if (not item["einddatum"])
+        or (datetime.strptime(item["einddatum"], "%d-%m-%Y").date() >= date.today())
+    ],
+    key=itemgetter("soort"),
+)
 
 # Count the occurrences of each combination of "soort" and "naam"
 counts = Counter((item["soort"], item["naam"]) for item in active_data)
@@ -64,10 +77,8 @@ else:
     # Recursively remove all files and folders in the output directory
     for root, dirs, files in os.walk(output_folder, topdown=False):
         for name in files:
-            logger.debug(f"Verwijder bestand: {os.path.join(root, name)}")
             os.remove(os.path.join(root, name))
         for name in dirs:
-            logger.debug(f"Verwijder map: {os.path.join(root, name)}")
             os.rmdir(os.path.join(root, name))
 
 # Group items by 'soort'

--- a/scripts/genereer_vera_referentiedata.py
+++ b/scripts/genereer_vera_referentiedata.py
@@ -60,6 +60,15 @@ for item in active_data:
 # Create output directory if not exists
 if not os.path.exists(output_folder):
     os.makedirs(output_folder)
+else:
+    # Recursively remove all files and folders in the output directory
+    for root, dirs, files in os.walk(output_folder, topdown=False):
+        for name in files:
+            logger.debug(f"Verwijder bestand: {os.path.join(root, name)}")
+            os.remove(os.path.join(root, name))
+        for name in dirs:
+            logger.debug(f"Verwijder map: {os.path.join(root, name)}")
+            os.rmdir(os.path.join(root, name))
 
 # Group items by 'soort'
 grouped_data = [(k, list(g)) for k, g in groupby(active_data, key=itemgetter("soort"))]
@@ -136,7 +145,6 @@ class {{ soort|remove_accents|title }}(Enum):
     \"\"\"
     {%- endif %}
 {% endfor %}
-
     @property
     def code(self) -> str | None:
         return self.value.code
@@ -144,6 +152,7 @@ class {{ soort|remove_accents|title }}(Enum):
     @property
     def naam(self) -> str | None:
         return self.value.naam
+
 """
 )
 

--- a/woningwaardering/vera/referentiedata/__init__.py
+++ b/woningwaardering/vera/referentiedata/__init__.py
@@ -109,8 +109,8 @@ from .leningdetailsoort import Leningdetailsoort
 from .leningsoort import Leningsoort
 from .maatschappelijklabel import Maatschappelijklabel
 from .machtigingsoort import Machtigingsoort
-from .materiaalsoort import Materiaalsoort
 from .materiaaldetailsoort import Materiaaldetailsoort
+from .materiaalsoort import Materiaalsoort
 from .medewerkerrol import Medewerkerrol
 from .medewerkersoort import Medewerkersoort
 from .meeteenheid import Meeteenheid
@@ -310,8 +310,8 @@ __all__ = [
     "Leningsoort",
     "Maatschappelijklabel",
     "Machtigingsoort",
-    "Materiaalsoort",
     "Materiaaldetailsoort",
+    "Materiaalsoort",
     "Medewerkerrol",
     "Medewerkersoort",
     "Meeteenheid",

--- a/woningwaardering/vera/referentiedata/ruimtedetailsoort.py
+++ b/woningwaardering/vera/referentiedata/ruimtedetailsoort.py
@@ -336,6 +336,22 @@ class Ruimtedetailsoort(Enum):
     advertentietekst worden gemeld.
     """
 
+    overloop = Referentiedata(
+        code="OVL",
+        naam="Overloop",
+    )
+    """
+    Gang op een bovenverdieping.
+    """
+
+    entree = Referentiedata(
+        code="ENT",
+        naam="Entree",
+    )
+    """
+    Ingang van een gebouw.
+    """
+
     @property
     def code(self) -> str | None:
         return self.value.code

--- a/woningwaardering/vera/referentiedata/ruimtedetailsoort.py
+++ b/woningwaardering/vera/referentiedata/ruimtedetailsoort.py
@@ -341,7 +341,7 @@ class Ruimtedetailsoort(Enum):
         naam="Overloop",
     )
     """
-    Gang op een bovenverdieping.
+    Verkeersruimte: Gang op een bovenverdieping.
     """
 
     entree = Referentiedata(
@@ -349,7 +349,7 @@ class Ruimtedetailsoort(Enum):
         naam="Entree",
     )
     """
-    Ingang van een gebouw.
+    Verkeersruimte: Ingang van een gebouw.
     """
 
     @property

--- a/woningwaardering/vera/referentiedata_uitbreiding.csv
+++ b/woningwaardering/vera/referentiedata_uitbreiding.csv
@@ -1,0 +1,3 @@
+Soort;Code;Naam;Omschrijving;Begindatum;Einddatum;Parent;Informatiedomein
+RUIMTEDETAILSOORT;OVL;Overloop;Gang op een bovenverdieping.;3-4-2024;;RUIMTESOORT.OVR;Vastgoed
+RUIMTEDETAILSOORT;ENT;Entree;Ingang van een gebouw.;3-4-2024;;RUIMTESOORT.OVR;Vastgoed

--- a/woningwaardering/vera/referentiedata_uitbreiding.csv
+++ b/woningwaardering/vera/referentiedata_uitbreiding.csv
@@ -1,3 +1,3 @@
 Soort;Code;Naam;Omschrijving;Begindatum;Einddatum;Parent;Informatiedomein
-RUIMTEDETAILSOORT;OVL;Overloop;Gang op een bovenverdieping.;3-4-2024;;RUIMTESOORT.OVR;Vastgoed
-RUIMTEDETAILSOORT;ENT;Entree;Ingang van een gebouw.;3-4-2024;;RUIMTESOORT.OVR;Vastgoed
+RUIMTEDETAILSOORT;OVL;Overloop;Verkeersruimte: Gang op een bovenverdieping.;3-4-2024;;RUIMTESOORT.OVR;Vastgoed
+RUIMTEDETAILSOORT;ENT;Entree;Verkeersruimte: Ingang van een gebouw.;3-4-2024;;RUIMTESOORT.OVR;Vastgoed


### PR DESCRIPTION
Wanneer de VERA standaard bepaalde referentiedata niet bevat, maar deze wel nodig is voor de woningwaardering, kunnen we hiermee de referentiedata uitbreiden.