### PR TITLE
verwarmd toegevoegd aan _Eenhedenruimte

### DIFF
--- a/woningwaardering/vera/bvg/generated.py
+++ b/woningwaardering/vera/bvg/generated.py
@@ -1311,6 +1311,11 @@ class EenhedenRuimte(BaseModel):
     """
     De ruimten die in verbinding staan met deze ruimte. Dit wordt gebruikt bij het berekenen van de waardering van kasten en verwarming van ruimten.
     """
+    # https://github.com/Aedes-datastandaarden/vera-referentiedata/issues/100
+    verwarmd: Optional[bool] = Field(default=None, alias="verwarmd")
+    """
+    Geeft aan of de ruimte verwarmd wordt door een onroerende zaak. Dit wordt gebruikt bij het berekenen van de waardering van een ruimte.
+    """
 
 
 class EenhedenStadsdeel(BaseModel):

--- a/woningwaardering/vera/bvg/model_uitbreidingen/eenheden_ruimte.py
+++ b/woningwaardering/vera/bvg/model_uitbreidingen/eenheden_ruimte.py
@@ -1,9 +1,10 @@
 from typing import Optional
+
 from pydantic import BaseModel, Field
 
 from woningwaardering.vera.bvg.generated import (
-    EenhedenRuimte,
     BouwkundigElementenBouwkundigElement,
+    EenhedenRuimte,
 )
 
 
@@ -28,4 +29,9 @@ class _EenhedenRuimte(BaseModel):
     )
     """
     De ruimten die in verbinding staan met deze ruimte. Dit wordt gebruikt bij het berekenen van de waardering van kasten en verwarming van ruimten.
+    """
+    # https://github.com/Aedes-datastandaarden/vera-referentiedata/issues/100
+    verwarmd: Optional[bool] = Field(default=None, alias="verwarmd")
+    """
+    Geeft aan of de ruimte verwarmd wordt door een onroerende zaak. Dit wordt gebruikt bij het berekenen van de waardering van een ruimte.
     """


### PR DESCRIPTION
Op dit moment ondersteunt VERA nog geen manier om verwarmd op ruimte niveau aan te geven. Als (tijdelijke) oplossing voegen we toe dat je met de boolean `verwarmd` op `Eenhedenruimte` kan aangeven of een ruimte verwarmd is of niet.

Zie ook:
https://github.com/Aedes-datastandaarden/vera-openapi/issues/41
https://github.com/Aedes-datastandaarden/vera-referentiedata/issues/100