### PR TITLE
TMS-124 open keukens

### DIFF
--- a/docs/implementatietoelichting-beleidsboeken/2024/zelfstandige_woonruimten.md
+++ b/docs/implementatietoelichting-beleidsboeken/2024/zelfstandige_woonruimten.md
@@ -295,4 +295,4 @@ Een open keuken wordt als afzonderlijk verwarmd vertrek beschouwd en krijgt dus 
 
 Ook een aanrecht dat is geplaatst in een woon- of slaapvertrek is een open keuken, ook als er geen duidelijke afscheiding tussen keukengedeelte en de rest van het vertrek aanwezig is.
 
-> Om een aanrecht in een woon- of slaapvertrek te waarderen als open keuken, dient de ruimte gespecificeerd te worden met detailsoortcode `WOK` voor Woonkamer/keuken, of er kan in de `bouwkundigeElementen` van een `Woonkamer`, `Slaapkamer` of `Woon-/slaapkamer` een bouwkundig element met detailsoortcode `AAN` voor aanrecht gespecificeerd worden.
+> Om een aanrecht in een woon- of slaapvertrek te waarderen als open keuken, moet de ruimte gespecificeerd worden met detailsoortcode `WOK` voor Woonkamer/keuken. Alternatief kan er in de bouwkundige elementen van een `Woonkamer`, `Slaapkamer` of `Woon-/slaapkamer` een bouwkundig element worden gespecificeerd met detailsoortcode `AAN` voor Aanrecht.

--- a/tests/data/input/generiek/37101000032.json
+++ b/tests/data/input/generiek/37101000032.json
@@ -348,7 +348,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {
@@ -524,7 +524,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -557,7 +557,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/12006000004.json
+++ b/tests/data/input/zelfstandige_woonruimten/12006000004.json
@@ -444,7 +444,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -477,7 +477,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/23003000050.json
+++ b/tests/data/input/zelfstandige_woonruimten/23003000050.json
@@ -67,7 +67,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -100,7 +100,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/25048000007.json
+++ b/tests/data/input/zelfstandige_woonruimten/25048000007.json
@@ -211,7 +211,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",

--- a/tests/data/input/zelfstandige_woonruimten/28018000044.json
+++ b/tests/data/input/zelfstandige_woonruimten/28018000044.json
@@ -153,7 +153,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -187,7 +187,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/37101000032.json
+++ b/tests/data/input/zelfstandige_woonruimten/37101000032.json
@@ -352,7 +352,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {
@@ -528,7 +528,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -561,7 +561,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/41027000003.json
+++ b/tests/data/input/zelfstandige_woonruimten/41027000003.json
@@ -426,7 +426,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -459,7 +459,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/41123000005.json
+++ b/tests/data/input/zelfstandige_woonruimten/41123000005.json
@@ -440,7 +440,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {
@@ -585,7 +585,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/41162000015.json
+++ b/tests/data/input/zelfstandige_woonruimten/41162000015.json
@@ -535,7 +535,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -569,7 +569,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/41164000002.json
+++ b/tests/data/input/zelfstandige_woonruimten/41164000002.json
@@ -32,7 +32,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -390,7 +390,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -422,7 +422,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/51011000042.json
+++ b/tests/data/input/zelfstandige_woonruimten/51011000042.json
@@ -257,7 +257,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -290,7 +290,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/71211000027.json
+++ b/tests/data/input/zelfstandige_woonruimten/71211000027.json
@@ -170,7 +170,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -203,7 +203,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/77795000000.json
+++ b/tests/data/input/zelfstandige_woonruimten/77795000000.json
@@ -100,7 +100,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {
@@ -363,7 +363,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -396,7 +396,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/81020000003.json
+++ b/tests/data/input/zelfstandige_woonruimten/81020000003.json
@@ -80,7 +80,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {
@@ -195,7 +195,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -227,7 +227,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/81065000089.json
+++ b/tests/data/input/zelfstandige_woonruimten/81065000089.json
@@ -116,7 +116,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",

--- a/tests/data/input/zelfstandige_woonruimten/85651000021.json
+++ b/tests/data/input/zelfstandige_woonruimten/85651000021.json
@@ -222,7 +222,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",
@@ -255,7 +255,7 @@
             "naam": "Sanitaire voorziening"
           },
           "detailSoort": {
-            "code": "TOI",
+            "code": "CLO",
             "naam": "Toilet"
           },
           "extraAttributen": {

--- a/tests/data/input/zelfstandige_woonruimten/87402000003.json
+++ b/tests/data/input/zelfstandige_woonruimten/87402000003.json
@@ -12,7 +12,7 @@
         "naam": "Overige ruimtes"
       },
       "detailSoort": {
-        "code": "TOI",
+        "code": "CLO",
         "naam": "Toiletruimte"
       },
       "naam": "Toiletruimte",

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/12006000004.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/12006000004.json
@@ -93,31 +93,31 @@
       "punten": 10.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/23003000050.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/23003000050.json
@@ -104,31 +104,31 @@
       "punten": 10.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/25048000007.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/25048000007.json
@@ -104,31 +104,31 @@
       "punten": 10.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/28018000044.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/28018000044.json
@@ -114,37 +114,37 @@
       "punten": 12.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/37101000032.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/37101000032.json
@@ -124,43 +124,43 @@
       "punten": 14.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41027000003.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41027000003.json
@@ -93,31 +93,31 @@
       "punten": 10.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41123000005.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41123000005.json
@@ -174,67 +174,67 @@
       "punten": 22.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41162000015.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41162000015.json
@@ -124,37 +124,37 @@
       "punten": 12.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41164000002.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/41164000002.json
@@ -124,43 +124,43 @@
       "punten": 14.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/51011000042.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/51011000042.json
@@ -113,43 +113,43 @@
       "punten": 14.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/71211000027.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/71211000027.json
@@ -124,37 +124,37 @@
       "punten": 12.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/77795000000.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/77795000000.json
@@ -114,43 +114,43 @@
       "punten": 9.75,
       "woningwaarderingen": [
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 0.75,
+          "punten": 0.75,
           "criterium": {
             "naam": "Zolder"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/81020000003.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/81020000003.json
@@ -114,37 +114,37 @@
       "punten": 9.0,
       "woningwaarderingen": [
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/81065000089.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/81065000089.json
@@ -114,37 +114,37 @@
       "punten": 11.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 1.0,
+          "punten": 1.0,
           "criterium": {
             "naam": "Wasruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/85651000021.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/85651000021.json
@@ -93,31 +93,31 @@
       "punten": 10.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/87402000003.json
+++ b/tests/data/output/zelfstandige_woonruimten/peildatum/2024-01-01/87402000003.json
@@ -104,31 +104,31 @@
       "punten": 10.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Badruimte"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "punten": 2.0,
           "criterium": {
             "naam": "Slaapkamer"
           }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/collectief_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/collectief_open_keuken.json
@@ -1,0 +1,109 @@
+{
+  "id": "37101000032",
+  "bouwjaar": 1924,
+  "klimaatbeheersingsoort": {
+    "code": "COL",
+    "naam": "Collectief"
+  },
+  "ruimten": [
+    {
+      "id": "Space_108010632",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": true,
+      "gemeenschappelijk": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "Aanrecht_108006231",
+          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "id": "Space_108006229",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Keuken",
+      "inhoud": 57.4359,
+      "oppervlakte": 20.3673,
+      "verwarmd": true,
+      "gemeenschappelijk": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "Aanrecht_108006231",
+          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "id": "Space_108017433",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 31.6776,
+      "oppervlakte": 15.9766,
+      "verwarmd": true,
+      "gemeenschappelijk": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "Aanrecht_108006231",
+          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    }
+  ]
+}

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/collectief_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/collectief_open_keuken.json
@@ -7,7 +7,6 @@
   },
   "ruimten": [
     {
-      "id": "Space_108010632",
       "soort": {
         "code": "VTK",
         "naam": "Vertrek"
@@ -16,15 +15,12 @@
         "code": "WOO",
         "naam": "Woonkamer"
       },
-      "naam": "Woonkamer",
+      "naam": "Verwarmde woonkamer",
       "inhoud": 111.528,
       "oppervlakte": 41.0028,
       "verwarmd": true,
-      "gemeenschappelijk": true,
       "bouwkundigeElementen": [
         {
-          "id": "Aanrecht_108006231",
-          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
           "naam": "Aanrecht",
           "omschrijving": "Aanrecht in Keuken",
           "soort": {
@@ -40,7 +36,6 @@
       ]
     },
     {
-      "id": "Space_108006229",
       "soort": {
         "code": "VTK",
         "naam": "Vertrek"
@@ -49,15 +44,12 @@
         "code": "KEU",
         "naam": "Keuken"
       },
-      "naam": "Keuken",
+      "naam": "Verwarmde keuken",
       "inhoud": 57.4359,
       "oppervlakte": 20.3673,
       "verwarmd": true,
-      "gemeenschappelijk": true,
       "bouwkundigeElementen": [
         {
-          "id": "Aanrecht_108006231",
-          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
           "naam": "Aanrecht",
           "omschrijving": "Aanrecht in Keuken",
           "soort": {
@@ -73,7 +65,6 @@
       ]
     },
     {
-      "id": "Space_108017433",
       "soort": {
         "code": "VTK",
         "naam": "Vertrek"
@@ -82,15 +73,12 @@
         "code": "SLA",
         "naam": "Slaapkamer"
       },
-      "naam": "Slaapkamer",
+      "naam": "Verwarmde slaapkamer",
       "inhoud": 31.6776,
       "oppervlakte": 15.9766,
       "verwarmd": true,
-      "gemeenschappelijk": true,
       "bouwkundigeElementen": [
         {
-          "id": "Aanrecht_108006231",
-          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
           "naam": "Aanrecht",
           "omschrijving": "Aanrecht in Keuken",
           "soort": {
@@ -104,6 +92,121 @@
           "lengte": 2700
         }
       ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOK",
+        "naam": "Woonkamer/keuken"
+      },
+      "naam": "Verwarmde woonkamer/keuken",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": true
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Onverwarmde woonkamer",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": false,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Onverwarmde keuken",
+      "inhoud": 57.4359,
+      "oppervlakte": 20.3673,
+      "verwarmd": false,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Onverwarmde slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 31.6776,
+      "oppervlakte": 15.9766,
+      "verwarmd": false,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOK",
+        "naam": "Woonkamer/keuken"
+      },
+      "naam": "Onverwarmde woonkamer/keuken",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": false
     }
   ]
 }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/collectief_open_keuken.md
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/collectief_open_keuken.md
@@ -1,0 +1,1 @@
+Fictieve eenheid met collectieve klimaatbeheersing. De eenheid heeft verwarmde en onverwarmde woonkamers, keukens, slaapkamers en woonkamers/keukens. Elke ruimte heeft specifieke eigenschappen, zoals oppervlakte en aanwezigheid van een aanrecht. Met deze eenheid wordt getest of open keukens correct worden gewaardeerd.

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/individueel_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/individueel_open_keuken.json
@@ -1,0 +1,109 @@
+{
+  "id": "37101000032",
+  "bouwjaar": 1924,
+  "klimaatbeheersingsoort": {
+    "code": "IND",
+    "naam": "Individueel"
+  },
+  "ruimten": [
+    {
+      "id": "Space_108010632",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Woonkamer",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": true,
+      "gemeenschappelijk": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "Aanrecht_108006231",
+          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "id": "Space_108006229",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Keuken",
+      "inhoud": 57.4359,
+      "oppervlakte": 20.3673,
+      "verwarmd": true,
+      "gemeenschappelijk": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "Aanrecht_108006231",
+          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "id": "Space_108017433",
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 31.6776,
+      "oppervlakte": 15.9766,
+      "verwarmd": true,
+      "gemeenschappelijk": true,
+      "bouwkundigeElementen": [
+        {
+          "id": "Aanrecht_108006231",
+          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    }
+  ]
+}

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/individueel_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/individueel_open_keuken.json
@@ -1,13 +1,10 @@
 {
-  "id": "37101000032",
-  "bouwjaar": 1924,
   "klimaatbeheersingsoort": {
     "code": "IND",
     "naam": "Individueel"
   },
   "ruimten": [
     {
-      "id": "Space_108010632",
       "soort": {
         "code": "VTK",
         "naam": "Vertrek"
@@ -16,15 +13,12 @@
         "code": "WOO",
         "naam": "Woonkamer"
       },
-      "naam": "Woonkamer",
+      "naam": "Verwarmde woonkamer",
       "inhoud": 111.528,
       "oppervlakte": 41.0028,
       "verwarmd": true,
-      "gemeenschappelijk": true,
       "bouwkundigeElementen": [
         {
-          "id": "Aanrecht_108006231",
-          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
           "naam": "Aanrecht",
           "omschrijving": "Aanrecht in Keuken",
           "soort": {
@@ -40,7 +34,6 @@
       ]
     },
     {
-      "id": "Space_108006229",
       "soort": {
         "code": "VTK",
         "naam": "Vertrek"
@@ -49,15 +42,12 @@
         "code": "KEU",
         "naam": "Keuken"
       },
-      "naam": "Keuken",
+      "naam": "Verwarmde keuken",
       "inhoud": 57.4359,
       "oppervlakte": 20.3673,
       "verwarmd": true,
-      "gemeenschappelijk": true,
       "bouwkundigeElementen": [
         {
-          "id": "Aanrecht_108006231",
-          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
           "naam": "Aanrecht",
           "omschrijving": "Aanrecht in Keuken",
           "soort": {
@@ -73,7 +63,6 @@
       ]
     },
     {
-      "id": "Space_108017433",
       "soort": {
         "code": "VTK",
         "naam": "Vertrek"
@@ -82,15 +71,12 @@
         "code": "SLA",
         "naam": "Slaapkamer"
       },
-      "naam": "Slaapkamer",
+      "naam": "Verwarmde slaapkamer",
       "inhoud": 31.6776,
       "oppervlakte": 15.9766,
       "verwarmd": true,
-      "gemeenschappelijk": true,
       "bouwkundigeElementen": [
         {
-          "id": "Aanrecht_108006231",
-          "id_bimmodel": "3ZBiDoTKz0JfnjhzfVcYcF",
           "naam": "Aanrecht",
           "omschrijving": "Aanrecht in Keuken",
           "soort": {
@@ -104,6 +90,121 @@
           "lengte": 2700
         }
       ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOK",
+        "naam": "Woonkamer/keuken"
+      },
+      "naam": "Verwarmde woonkamer/keuken",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": true
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOO",
+        "naam": "Woonkamer"
+      },
+      "naam": "Onverwarmde woonkamer",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": false,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "KEU",
+        "naam": "Keuken"
+      },
+      "naam": "Onverwarmde keuken",
+      "inhoud": 57.4359,
+      "oppervlakte": 20.3673,
+      "verwarmd": false,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "SLA",
+        "naam": "Onverwarmde slaapkamer"
+      },
+      "naam": "Slaapkamer",
+      "inhoud": 31.6776,
+      "oppervlakte": 15.9766,
+      "verwarmd": false,
+      "bouwkundigeElementen": [
+        {
+          "naam": "Aanrecht",
+          "omschrijving": "Aanrecht in Keuken",
+          "soort": {
+            "code": "KEU",
+            "naam": "Keuken voorziening"
+          },
+          "detailSoort": {
+            "code": "AAN",
+            "naam": "Aanrecht"
+          },
+          "lengte": 2700
+        }
+      ]
+    },
+    {
+      "soort": {
+        "code": "VTK",
+        "naam": "Vertrek"
+      },
+      "detailSoort": {
+        "code": "WOK",
+        "naam": "Woonkamer/keuken"
+      },
+      "naam": "Onverwarmde woonkamer/keuken",
+      "inhoud": 111.528,
+      "oppervlakte": 41.0028,
+      "verwarmd": false
     }
   ]
 }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/individueel_open_keuken.md
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/input/individueel_open_keuken.md
@@ -1,0 +1,1 @@
+Fictieve eenheid met individuele klimaatbeheersing. De eenheid heeft verwarmde en onverwarmde woonkamers, keukens, slaapkamers en woonkamers/keukens. Elke ruimte heeft specifieke eigenschappen, zoals oppervlakte en aanwezigheid van een aanrecht. Met deze eenheid wordt getest of open keukens correct worden gewaardeerd.

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_max_4_punten_overige_ruimten.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_max_4_punten_overige_ruimten.json
@@ -14,37 +14,37 @@
       "punten": 4.0,
       "woningwaarderingen": [
         {
-          "aantal": 0.75,
+          "punten": 0.75,
           "criterium": {
             "naam": "Woonkamer1"
           }
         },
         {
-          "aantal": 0.75,
+          "punten": 0.75,
           "criterium": {
             "naam": "Woonkamer2"
           }
         },
         {
-          "aantal": 0.75,
+          "punten": 0.75,
           "criterium": {
             "naam": "Woonkamer3"
           }
         },
         {
-          "aantal": 0.75,
+          "punten": 0.75,
           "criterium": {
             "naam": "Woonkamer4"
           }
         },
         {
-          "aantal": 0.75,
+          "punten": 0.75,
           "criterium": {
             "naam": "Woonkamer5"
           }
         },
         {
-          "aantal": 0.25,
+          "punten": 0.25,
           "criterium": {
             "naam": "Woonkamer6"
           }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_open_keuken.json
@@ -11,36 +11,54 @@
           "naam": "Verwarming"
         }
       },
-      "punten": 6.0,
+      "punten": 10.5,
       "woningwaarderingen": [
         {
           "aantal": 1.5,
           "criterium": {
-            "naam": "Woonkamer"
+            "naam": "Verwarmde woonkamer"
           }
         },
         {
           "aantal": 1.5,
           "criterium": {
-            "naam": "Open keuken"
+            "naam": "Open keuken in Verwarmde woonkamer"
           }
         },
         {
           "aantal": 1.5,
           "criterium": {
-            "naam": "Keuken"
+            "naam": "Verwarmde keuken"
           }
         },
         {
           "aantal": 1.5,
           "criterium": {
-            "naam": "Slaapkamer"
+            "naam": "Verwarmde slaapkamer"
+          }
+        },
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Open keuken in Verwarmde slaapkamer"
+          }
+        },
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Verwarmde woonkamer/keuken"
+          }
+        },
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Open keuken in Verwarmde woonkamer/keuken"
           }
         }
       ]
     }
   ],
-  "punten": 6.0,
+  "punten": 10.5,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_open_keuken.json
@@ -14,43 +14,43 @@
       "punten": 10.5,
       "woningwaarderingen": [
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Verwarmde woonkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Open keuken in Verwarmde woonkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Verwarmde keuken"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Verwarmde slaapkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Open keuken in Verwarmde slaapkamer"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Verwarmde woonkamer/keuken"
           }
         },
         {
-          "aantal": 1.5,
+          "punten": 1.5,
           "criterium": {
             "naam": "Open keuken in Verwarmde woonkamer/keuken"
           }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/collectief_open_keuken.json
@@ -1,0 +1,48 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "VZE",
+          "naam": "Verwarming"
+        }
+      },
+      "punten": 6.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Woonkamer"
+          }
+        },
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Open keuken"
+          }
+        },
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Keuken"
+          }
+        },
+        {
+          "aantal": 1.5,
+          "criterium": {
+            "naam": "Slaapkamer"
+          }
+        }
+      ]
+    }
+  ],
+  "punten": 6.0,
+  "stelsel": {
+    "code": "ZEL",
+    "naam": "Zelfstandige woonruimten"
+  }
+}

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_max_4_punten_overige_ruimten.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_max_4_punten_overige_ruimten.json
@@ -14,25 +14,25 @@
       "punten": 4.0,
       "woningwaarderingen": [
         {
-          "aantal": 1.0,
+          "punten": 1.0,
           "criterium": {
             "naam": "Woonkamer1"
           }
         },
         {
-          "aantal": 1.0,
+          "punten": 1.0,
           "criterium": {
             "naam": "Woonkamer2"
           }
         },
         {
-          "aantal": 1.0,
+          "punten": 1.0,
           "criterium": {
             "naam": "Woonkamer3"
           }
         },
         {
-          "aantal": 1.0,
+          "punten": 1.0,
           "criterium": {
             "naam": "Woonkamer4"
           }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_open_keuken.json
@@ -14,43 +14,43 @@
       "punten": 14.0,
       "woningwaarderingen": [
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Verwarmde woonkamer"
           }
         },
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Open keuken in Verwarmde woonkamer"
           }
         },
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Verwarmde keuken"
           }
         },
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Verwarmde slaapkamer"
           }
         },
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Open keuken in Verwarmde slaapkamer"
           }
         },
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Verwarmde woonkamer/keuken"
           }
         },
         {
-          "aantal": 2,
+          "punten": 2,
           "criterium": {
             "naam": "Open keuken in Verwarmde woonkamer/keuken"
           }

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_open_keuken.json
@@ -11,36 +11,54 @@
           "naam": "Verwarming"
         }
       },
-      "punten": 8.0,
+      "punten": 14.0,
       "woningwaarderingen": [
         {
-          "aantal": 2.0,
+          "aantal": 2,
           "criterium": {
-            "naam": "Woonkamer"
+            "naam": "Verwarmde woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "aantal": 2,
           "criterium": {
-            "naam": "Open keuken"
+            "naam": "Open keuken in Verwarmde woonkamer"
           }
         },
         {
-          "aantal": 2.0,
+          "aantal": 2,
           "criterium": {
-            "naam": "Keuken"
+            "naam": "Verwarmde keuken"
           }
         },
         {
-          "aantal": 2.0,
+          "aantal": 2,
           "criterium": {
-            "naam": "Slaapkamer"
+            "naam": "Verwarmde slaapkamer"
+          }
+        },
+        {
+          "aantal": 2,
+          "criterium": {
+            "naam": "Open keuken in Verwarmde slaapkamer"
+          }
+        },
+        {
+          "aantal": 2,
+          "criterium": {
+            "naam": "Verwarmde woonkamer/keuken"
+          }
+        },
+        {
+          "aantal": 2,
+          "criterium": {
+            "naam": "Open keuken in Verwarmde woonkamer/keuken"
           }
         }
       ]
     }
   ],
-  "punten": 8.0,
+  "punten": 14.0,
   "stelsel": {
     "code": "ZEL",
     "naam": "Zelfstandige woonruimten"

--- a/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_open_keuken.json
+++ b/tests/stelsels/zelfstandige_woonruimten/verwarming/data/output/peildatum/2024-01-01/individueel_open_keuken.json
@@ -1,0 +1,48 @@
+{
+  "groepen": [
+    {
+      "criteriumGroep": {
+        "stelsel": {
+          "code": "ZEL",
+          "naam": "Zelfstandige woonruimten"
+        },
+        "stelselgroep": {
+          "code": "VZE",
+          "naam": "Verwarming"
+        }
+      },
+      "punten": 8.0,
+      "woningwaarderingen": [
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "naam": "Woonkamer"
+          }
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "naam": "Open keuken"
+          }
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "naam": "Keuken"
+          }
+        },
+        {
+          "aantal": 2.0,
+          "criterium": {
+            "naam": "Slaapkamer"
+          }
+        }
+      ]
+    }
+  ],
+  "punten": 8.0,
+  "stelsel": {
+    "code": "ZEL",
+    "naam": "Zelfstandige woonruimten"
+  }
+}

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -127,7 +127,9 @@ def naar_tabel(
         )
         else [woningwaardering_resultaat]
     ):
-        for woningwaardering in woningwaardering_groep.woningwaarderingen or []:
+        woningwaarderingen = woningwaardering_groep.woningwaarderingen or []
+        aantal_waarderingen = len(woningwaarderingen)
+        for index, woningwaardering in enumerate(woningwaarderingen):
             if (
                 woningwaardering_groep.criterium_groep
                 and woningwaardering_groep.criterium_groep.stelselgroep
@@ -137,12 +139,13 @@ def naar_tabel(
                     [
                         woningwaardering_groep.criterium_groep.stelselgroep.naam,
                         woningwaardering.criterium.naam,
-                        woningwaardering.aantal,
+                        woningwaardering.aantal or "",
                         woningwaardering.criterium.meeteenheid.naam
                         if woningwaardering.criterium.meeteenheid is not None
                         else "",
                         woningwaardering.punten or "",
-                    ]
+                    ],
+                    divider=index + 1 == aantal_waarderingen,
                 )
         if (
             woningwaardering_groep.criterium_groep
@@ -156,13 +159,22 @@ def naar_tabel(
                         sum(
                             [
                                 Decimal(woningwaardering.aantal)
-                                for woningwaardering in woningwaardering_groep.woningwaarderingen
-                                or []
+                                for woningwaardering in woningwaarderingen
                                 if woningwaardering.aantal is not None
                             ]
                         )
+                    )
+                    or "",
+                    ", ".join(
+                        list(
+                            {
+                                woningwaardering.criterium.meeteenheid.naam or ""
+                                for woningwaardering in woningwaarderingen
+                                if woningwaardering.criterium is not None
+                                and woningwaardering.criterium.meeteenheid is not None
+                            }
+                        )
                     ),
-                    "",
                     woningwaardering_groep.punten,
                 ],
                 divider=True,

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten_2024.py
@@ -2,7 +2,8 @@ from decimal import ROUND_HALF_UP, Decimal
 
 from loguru import logger
 
-from woningwaardering.stelsels import Stelselgroepversie, utils
+from woningwaardering.stelsels import Stelselgroepversie
+from woningwaardering.stelsels.utils import naar_tabel
 from woningwaardering.stelsels.zelfstandige_woonruimten.utils import (
     classificeer_ruimte,
     voeg_oppervlakte_kasten_toe_aan_ruimte,
@@ -26,6 +27,7 @@ from woningwaardering.vera.referentiedata import (
 from woningwaardering.vera.referentiedata.bouwkundigelementdetailsoort import (
     Bouwkundigelementdetailsoort,
 )
+from woningwaardering.vera.utils import heeft_bouwkundig_element
 
 
 def _oppervlakte_zolder_overige_ruimte(ruimte: EenhedenRuimte) -> float:
@@ -39,12 +41,7 @@ def _oppervlakte_zolder_overige_ruimte(ruimte: EenhedenRuimte) -> float:
         float: De berekende oppervlakte voor de zolder.
     """
     if ruimte.detail_soort is not None and ruimte.oppervlakte is not None:
-        trap = [
-            element.detail_soort
-            for element in ruimte.bouwkundige_elementen or []
-            if element.detail_soort
-            and element.detail_soort.code == Bouwkundigelementdetailsoort.trap.code
-        ]
+        trap = heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.trap.value)
 
         if trap:
             logger.debug(
@@ -56,12 +53,9 @@ def _oppervlakte_zolder_overige_ruimte(ruimte: EenhedenRuimte) -> float:
                 )
             )
 
-        vlizotrap = [
-            element.detail_soort
-            for element in ruimte.bouwkundige_elementen or []
-            if element.detail_soort
-            and element.detail_soort.code == Bouwkundigelementdetailsoort.vlizotrap.code
-        ]
+        vlizotrap = heeft_bouwkundig_element(
+            ruimte, Bouwkundigelementdetailsoort.vlizotrap.value
+        )
 
         if vlizotrap:
             logger.debug(
@@ -211,6 +205,6 @@ if __name__ == "__main__":
         )
     )
 
-    tabel = utils.naar_tabel(woningwaardering_resultaat)
+    tabel = naar_tabel(woningwaardering_resultaat)
 
     print(tabel)

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten_2024.py
@@ -41,7 +41,7 @@ def _oppervlakte_zolder_overige_ruimte(ruimte: EenhedenRuimte) -> float:
         float: De berekende oppervlakte voor de zolder.
     """
     if ruimte.detail_soort is not None and ruimte.oppervlakte is not None:
-        trap = heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.trap.value)
+        trap = heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.trap.code)
 
         if trap:
             logger.debug(
@@ -54,7 +54,7 @@ def _oppervlakte_zolder_overige_ruimte(ruimte: EenhedenRuimte) -> float:
             )
 
         vlizotrap = heeft_bouwkundig_element(
-            ruimte, Bouwkundigelementdetailsoort.vlizotrap.value
+            ruimte, Bouwkundigelementdetailsoort.vlizotrap.code
         )
 
         if vlizotrap:

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/utils.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/utils.py
@@ -7,7 +7,7 @@ from woningwaardering.vera.referentiedata import (
     Ruimtesoort,
     Woningwaarderingstelsel,
 )
-from woningwaardering.vera.utils import badruimte_met_toilet
+from woningwaardering.vera.utils import badruimte_met_toilet, heeft_bouwkundig_element
 
 
 def classificeer_ruimte(ruimte: EenhedenRuimte) -> Ruimtesoort | None:
@@ -78,17 +78,7 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> Ruimtesoort | None:
             return None
 
     if ruimte.detail_soort.code == Ruimtedetailsoort.zolder.code:
-        bouwkundige_elementen_codes = (
-            [
-                element.detail_soort.code
-                for element in ruimte.bouwkundige_elementen
-                if element.detail_soort is not None
-            ]
-            if ruimte.bouwkundige_elementen
-            else []
-        )
-
-        if Bouwkundigelementdetailsoort.trap.code in bouwkundige_elementen_codes:
+        if heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.trap.value):
             logger.debug(
                 f"Vaste trap gevonden in {ruimte.naam} ({ruimte.id}): wordt gewaardeerd als {ruimte.soort.naam}"
             )
@@ -101,7 +91,9 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> Ruimtesoort | None:
                 return Ruimtesoort.overige_ruimtes
             else:
                 return None
-        elif Bouwkundigelementdetailsoort.vlizotrap.code in bouwkundige_elementen_codes:
+        elif heeft_bouwkundig_element(
+            ruimte, Bouwkundigelementdetailsoort.vlizotrap.value
+        ):
             logger.debug(
                 f"Vlizo trap gevonden in {ruimte.naam} ({ruimte.id}): wordt gewaardeerd als {Ruimtesoort.overige_ruimtes}"
             )

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/utils.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/utils.py
@@ -78,7 +78,7 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> Ruimtesoort | None:
             return None
 
     if ruimte.detail_soort.code == Ruimtedetailsoort.zolder.code:
-        if heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.trap.value):
+        if heeft_bouwkundig_element(ruimte, Bouwkundigelementdetailsoort.trap.code):
             logger.debug(
                 f"Vaste trap gevonden in {ruimte.naam} ({ruimte.id}): wordt gewaardeerd als {ruimte.soort.naam}"
             )
@@ -92,7 +92,7 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> Ruimtesoort | None:
             else:
                 return None
         elif heeft_bouwkundig_element(
-            ruimte, Bouwkundigelementdetailsoort.vlizotrap.value
+            ruimte, Bouwkundigelementdetailsoort.vlizotrap.code
         ):
             logger.debug(
                 f"Vlizo trap gevonden in {ruimte.naam} ({ruimte.id}): wordt gewaardeerd als {Ruimtesoort.overige_ruimtes}"

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming_2024.py
@@ -20,9 +20,12 @@ from woningwaardering.vera.bvg.generated import (
 from woningwaardering.vera.referentiedata import (
     Eenheidklimaatbeheersingsoort,
     Ruimtesoort,
+    Ruimtedetailsoort,
     Woningwaarderingstelsel,
     Woningwaarderingstelselgroep,
+    Bouwkundigelementdetailsoort,
 )
+from woningwaardering.vera.utils import heeft_bouwkundig_element
 
 
 class Verwarming2024(Stelselgroepversie):
@@ -117,6 +120,28 @@ class Verwarming2024(Stelselgroepversie):
                     aantal=punten,
                 )
             )
+
+            if (
+                ruimte.detail_soort.code
+                == Ruimtedetailsoort.woonkamer_en_of_keuken.code
+                or ruimte.detail_soort.code
+                in [
+                    Ruimtedetailsoort.woonkamer.code,
+                    Ruimtedetailsoort.woon_en_of_slaapkamer.code,
+                    Ruimtedetailsoort.slaapkamer.code,
+                ]
+                and heeft_bouwkundig_element(
+                    ruimte, Bouwkundigelementdetailsoort.aanrecht.code
+                )
+            ):
+                woningwaardering_groep.woningwaarderingen.append(
+                    WoningwaarderingResultatenWoningwaardering(
+                        criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
+                            naam=f"Open keuken in {ruimte.naam}",
+                        ),
+                        aantal=punten,
+                    )
+                )
 
         punten = Decimal(
             sum(

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming_2024.py
@@ -117,7 +117,7 @@ class Verwarming2024(Stelselgroepversie):
                     criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                         naam=ruimte.naam,
                     ),
-                    aantal=punten,
+                    punten=punten,
                 )
             )
 
@@ -139,15 +139,15 @@ class Verwarming2024(Stelselgroepversie):
                         criterium=WoningwaarderingResultatenWoningwaarderingCriterium(
                             naam=f"Open keuken in {ruimte.naam}",
                         ),
-                        aantal=punten,
+                        punten=punten,
                     )
                 )
 
         punten = Decimal(
             sum(
-                Decimal(str(woningwaardering.aantal))
+                Decimal(str(woningwaardering.punten))
                 for woningwaardering in woningwaardering_groep.woningwaarderingen or []
-                if woningwaardering.aantal is not None
+                if woningwaardering.punten is not None
             )
         )
 

--- a/woningwaardering/vera/utils.py
+++ b/woningwaardering/vera/utils.py
@@ -44,7 +44,7 @@ def heeft_bouwkundig_element(
         *bouwkundige_elementen_codes (str): De codes van de bouwkundige elementen waarop gecontroleerd moet worden.
 
     Returns:
-        bool: True als de ruimte een van de opgegeven bouwkundige elementen bevat, anders False.
+        bool: True als de ruimte één of meerdere van de opgegeven bouwkundige elementen bevat, anders False.
     """
     ruimte_bouwkundige_elementen_codes = {
         element.detail_soort.code

--- a/woningwaardering/vera/utils.py
+++ b/woningwaardering/vera/utils.py
@@ -1,6 +1,6 @@
 from loguru import logger
 
-from woningwaardering.vera.bvg.generated import EenhedenRuimte, Referentiedata
+from woningwaardering.vera.bvg.generated import EenhedenRuimte
 from woningwaardering.vera.referentiedata import (
     Bouwkundigelementdetailsoort,
     Ruimtedetailsoort,
@@ -28,20 +28,20 @@ def badruimte_met_toilet(ruimte: EenhedenRuimte) -> bool:
         ruimte.detail_soort.code
         in [Ruimtedetailsoort.doucheruimte.code, Ruimtedetailsoort.badkamer.code]
         and heeft_bouwkundig_element(
-            ruimte, Bouwkundigelementdetailsoort.closetcombinatie.value
+            ruimte, Bouwkundigelementdetailsoort.closetcombinatie.code
         )
     )
 
 
 def heeft_bouwkundig_element(
-    ruimte: EenhedenRuimte, *bouwkundige_elementen: Referentiedata
+    ruimte: EenhedenRuimte, *bouwkundige_elementen_codes: str
 ) -> bool:
     """
     Controleert of een ruimte een specifiek bouwkundig element bevat.
 
     Args:
         ruimte (EenhedenRuimte): De ruimte waarin gecontroleerd moet worden.
-        *bouwkundige_elementen (Referentiedata): De bouwkundige elementen waarop gecontroleerd moet worden.
+        *bouwkundige_elementen_codes (str): De codes van de bouwkundige elementen waarop gecontroleerd moet worden.
 
     Returns:
         bool: True als de ruimte een van de opgegeven bouwkundige elementen bevat, anders False.
@@ -52,8 +52,6 @@ def heeft_bouwkundig_element(
         if element.detail_soort is not None
     }
 
-    bouwkundige_elementen_codes = {element.code for element in bouwkundige_elementen}
-
     return any(
-        ruimte_bouwkundige_elementen_codes.intersection(bouwkundige_elementen_codes)
+        ruimte_bouwkundige_elementen_codes.intersection({*bouwkundige_elementen_codes})
     )

--- a/woningwaardering/vera/utils.py
+++ b/woningwaardering/vera/utils.py
@@ -36,6 +36,16 @@ def badruimte_met_toilet(ruimte: EenhedenRuimte) -> bool:
 def heeft_bouwkundig_element(
     ruimte: EenhedenRuimte, *bouwkundige_elementen: Referentiedata
 ) -> bool:
+    """
+    Controleert of een ruimte een specifiek bouwkundig element bevat.
+
+    Args:
+        ruimte (EenhedenRuimte): De ruimte waarin gecontroleerd moet worden.
+        *bouwkundige_elementen (Referentiedata): De bouwkundige elementen waarop gecontroleerd moet worden.
+
+    Returns:
+        bool: True als de ruimte een van de opgegeven bouwkundige elementen bevat, anders False.
+    """
     ruimte_bouwkundige_elementen_codes = {
         element.detail_soort.code
         for element in ruimte.bouwkundige_elementen or []


### PR DESCRIPTION
Implementatie van regels mbt verwarmde open keukens. Daarnaast ook fallback voor foutief gebruikte code voor closetcombinaties verwijderd, een util functie voor het zoeken naar bouwkundige elementen toegevoegd en de telling van Verwarming van `aantal` naar `punten` verplaatst, en opmaak output tabel aangepast.
Was:
<img width="830" alt="image" src="https://github.com/WoonstadRotterdamTemp/woningwaardering/assets/311514/175c71ca-0102-43f8-a79b-47ad277807d1">
Nu:
<img width="833" alt="image" src="https://github.com/WoonstadRotterdamTemp/woningwaardering/assets/311514/58caa13f-824e-454d-8529-3fa4498b5c81">
