### PR TITLE
TMS-126 logging exceptions

### DIFF
--- a/scripts/genereer_test_output.py
+++ b/scripts/genereer_test_output.py
@@ -12,6 +12,8 @@ from woningwaardering.vera.bvg.generated import (
     EenhedenEenheid,
 )
 
+logger.enable("woningwaardering")
+
 # zet logger level to INFO
 logger.remove()
 stdout_id = logger.add(sys.stdout, level="INFO")

--- a/scripts/genereer_vera_referentiedata.py
+++ b/scripts/genereer_vera_referentiedata.py
@@ -188,7 +188,7 @@ class {{ soort|remove_accents|title }}(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def zelfstandige_woonruimten_input_en_outputmodel(
     # Extract date from string
     peildatum_match = re.search(r"\d{4}-\d{2}-\d{2}", str(output_file_path))
     if peildatum_match is None:
-        raise ValueError(f"Geen datum gevonden in bestandsnaam {output_file_path}")
+        raise ValueError(f"geen datum gevonden in bestandsnaam {output_file_path}")
     peildatum = datetime.strptime(peildatum_match.group(0), "%Y-%m-%d").date()
 
     # get input model

--- a/tests/stelsels/config/test_config.py
+++ b/tests/stelsels/config/test_config.py
@@ -10,9 +10,9 @@ from woningwaardering.vera.referentiedata import (
 
 @pytest.mark.parametrize("stelsel", [Woningwaarderingstelsel.zelfstandige_woonruimten])
 def test_stelselconfig(stelsel: Woningwaarderingstelsel) -> None:
-    """This function valdiates the Stelselsconfig.yml"""
+    """Deze functie valideert de Stelselsconfig.yml"""
     try:
         _ = Stelselconfig.load(stelsel=stelsel)
     except ValidationError as e:
-        print(e, f"Stelsel {stelsel} does not have a valid yml config")
+        print(e, f"Stelsel {stelsel} heeft geen valide yml config")
         raise

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,7 +60,7 @@ def laad_specifiek_input_en_output_model(
     input_path = module_path / f"data/input/{file_name}"
     peildatum_match = re.search(r"\d{4}-\d{2}-\d{2}", str(output_json_path))
     if peildatum_match is None:
-        raise ValueError(f"Geen datum gevonden in bestandsnaam {file_name}")
+        raise ValueError(f"geen datum gevonden in bestandsnaam {file_name}")
     peildatum = datetime.strptime(peildatum_match.group(0), "%Y-%m-%d").date()
     with open(input_path, "r+") as f:
         eenheid_input = EenhedenEenheid.model_validate_json(f.read())

--- a/woningwaardering/__init__.py
+++ b/woningwaardering/__init__.py
@@ -31,6 +31,13 @@ def handle_unhandled_exception(
     exception_value: BaseException,
     exception_traceback: TracebackType | None,
 ) -> None:
+    """
+    Deze functie zorgt ervoor dat onverwachte uitzonderingen gelogged worden
+    en negeert daarbij uitzonderingen die ontstaan zijn door een KeyboardInterrupt.
+    Als de uitzondering van het type `KeyboardInterrupt` is, wordt de uitvoering
+    onderbroken zonder enige verdere actie.
+    Een voorbeeld van een `KeyboardInterrupt` is wanneer een gebruiker op Ctrl+C drukt.
+    """
     if issubclass(exception_type, KeyboardInterrupt):
         return
     logger.exception(exception_value)

--- a/woningwaardering/__init__.py
+++ b/woningwaardering/__init__.py
@@ -1,8 +1,12 @@
 from decimal import BasicContext, setcontext
 import os
+import sys
 import time
+from types import TracebackType
 from loguru import logger
 
+
+logger.disable("woningwaardering")
 
 # Set context for all calculations to avoid rounding errors
 # See https://docs.python.org/3/library/decimal.html#rounding
@@ -20,3 +24,18 @@ if timezone is None:
     time.tzset()
 else:
     logger.debug(f"Tijdzone ingesteld via environment variable: {timezone}")
+
+
+def handle_unhandled_exception(
+    exception_type: type[BaseException],
+    exception_value: BaseException,
+    exception_traceback: TracebackType | None,
+) -> None:
+    if issubclass(exception_type, KeyboardInterrupt):
+        return
+    logger.exception(exception_value)
+    sys.__excepthook__(exception_type, exception_value, exception_traceback)
+    return
+
+
+sys.excepthook = handle_unhandled_exception

--- a/woningwaardering/stelsels/config/config.py
+++ b/woningwaardering/stelsels/config/config.py
@@ -45,8 +45,8 @@ class Stelselconfig(BaseModel):
         try:
             stelsel_config = cls(**config)
 
-        except ValidationError as e:
-            logger.error(f"Geen valide stelsel configuratie in {path}.", e)
+        except ValidationError:
+            logger.error(f"Configuratie in {path} is niet valide.")
             raise
 
         logger.info(f"Configuratie voor stelsel '{stelsel.value.naam}' geladen.")

--- a/woningwaardering/stelsels/stelsel.py
+++ b/woningwaardering/stelsels/stelsel.py
@@ -111,7 +111,7 @@ class Stelsel:
             peildatum,
         ):
             raise ValueError(
-                f"Stelsel {stelsel.value.naam} met begindatum {config.begindatum} en einddatum {config.einddatum} is niet geldig op peildatum {peildatum}."
+                f"stelsel {stelsel.value.naam} met begindatum {config.begindatum} en einddatum {config.einddatum} is niet geldig op peildatum {peildatum}."
             )
 
         geldige_stelselgroepen: list[Stelselgroep] = [
@@ -127,7 +127,7 @@ class Stelsel:
 
         if not geldige_stelselgroepen:
             raise ValueError(
-                f"{stelsel.value.naam}: geen geldige stelselgroepen gevonden met peildatum {peildatum}."
+                f"geen geldige stelselgroepen gevonden voor {stelsel.value.naam} met peildatum {peildatum}"
             )
 
         return geldige_stelselgroepen

--- a/woningwaardering/stelsels/stelselgroep.py
+++ b/woningwaardering/stelsels/stelselgroep.py
@@ -67,12 +67,12 @@ class _StelselgroepABC(ABC):
 
         if not geldige_stelselgroep_versie_configs:
             raise ValueError(
-                f"{stelsel}: geen geldige stelselgroep configuratie gevonden met peildatum {peildatum}."
+                f"geen geldige stelselgroep configuratie gevonden voor stelsel {stelsel} met peildatum {peildatum}"
             )
 
         if len(geldige_stelselgroep_versie_configs) > 1:
             raise ValueError(
-                f"{stelsel.value.naam}: meerdere geldige stelselgroep configuraties gevonden met peildatum {peildatum}: {geldige_stelselgroep_versie_configs}."
+                f"meerdere geldige stelselgroep configuraties gevonden voor {stelsel.value.naam} met peildatum {peildatum}: {geldige_stelselgroep_versie_configs}"
             )
 
         logger.debug(

--- a/woningwaardering/stelsels/utils.py
+++ b/woningwaardering/stelsels/utils.py
@@ -37,7 +37,7 @@ def import_class(module_path: str, class_naam: str, class_type: Type[T]) -> Type
         class_: Type[T] = getattr(module, class_naam)
         if not issubclass(class_, class_type):
             raise TypeError(
-                f"Class '{class_.__qualname__}' in '{class_.__module__}' is niet van het type '{class_type.__qualname__}'."
+                f"class '{class_.__qualname__}' in '{class_.__module__}' is niet van het type '{class_type.__qualname__}'"
             )
 
     except ModuleNotFoundError as e:

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from loguru import logger
+
 from woningwaardering.stelsels import Stelselgroep, utils
 from woningwaardering.vera.bvg.generated import (
     EenhedenEenheid,
@@ -20,6 +22,8 @@ class OppervlakteVanOverigeRuimten(Stelselgroep):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten(
         peildatum=date(2025, 1, 1)
     )

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_overige_ruimten/oppervlakte_van_overige_ruimten_2024.py
@@ -109,12 +109,10 @@ class OppervlakteVanOverigeRuimten2024(Stelselgroepversie):
 
         for ruimte in eenheid.ruimten or []:
             if ruimte.oppervlakte is None:
-                error_msg = f"Ruimte {ruimte.id} heeft geen oppervlakte"
-                logger.error(error_msg)
+                error_msg = f"ruimte {ruimte.id} heeft geen oppervlakte"
                 raise TypeError(error_msg)
             if ruimte.detail_soort is None:
-                error_msg = f"Ruimte {ruimte.id} heeft geen detailsoort"
-                logger.error(error_msg)
+                error_msg = f"ruimte {ruimte.id} heeft geen detailsoort"
                 raise TypeError(error_msg)
 
             criterium_naam = voeg_oppervlakte_kasten_toe_aan_ruimte(ruimte)
@@ -190,6 +188,8 @@ class OppervlakteVanOverigeRuimten2024(Stelselgroepversie):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     oppervlakte_van_overige_ruimten = OppervlakteVanOverigeRuimten2024()
     with open(
         "tests/data/input/zelfstandige_woonruimten/85651000021.json",

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from loguru import logger
+
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
 from woningwaardering.vera.bvg.generated import (
@@ -19,6 +21,8 @@ class OppervlakteVanVertrekken(Stelselgroep):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     oppervlakte_van_vertrekken = OppervlakteVanVertrekken(peildatum=date(2024, 1, 1))
     with open(
         "./tests/data/input/zelfstandige_woonruimten/41164000002.json", "r+"

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/oppervlakte_van_vertrekken/oppervlakte_van_vertrekken_2024.py
@@ -85,6 +85,8 @@ class OppervlakteVanVertrekken2024(Stelselgroepversie):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     file = open(
         "tests/data/input/zelfstandige_woonruimten/12006000004.json",
         "r+",

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/utils.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/utils.py
@@ -25,18 +25,15 @@ def classificeer_ruimte(ruimte: EenhedenRuimte) -> Ruimtesoort | None:
         TypeError: Als de ruimte ontbrekende informatie heeft, zoals oppervlakte, soort of detailsoort.
     """
     if ruimte.oppervlakte is None:
-        error_msg = f"Ruimte {ruimte.id} heeft geen oppervlakte en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
-        logger.error(error_msg)
+        error_msg = f"ruimte {ruimte.id} heeft geen oppervlakte en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
         raise TypeError(error_msg)
 
     if ruimte.soort is None or ruimte.soort.code is None:
-        error_msg = f"Ruimte {ruimte.id} heeft geen soort en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
-        logger.error(error_msg)
+        error_msg = f"ruimte {ruimte.id} heeft geen soort en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
         raise TypeError(error_msg)
 
     if ruimte.detail_soort is None:
-        error_msg = f"Ruimte {ruimte.id} heeft geen detailsoort en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
-        logger.error(error_msg)
+        error_msg = f"ruimte {ruimte.id} heeft geen detailsoort en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
         raise TypeError(error_msg)
 
     if ruimte.detail_soort.code in [
@@ -122,13 +119,11 @@ def voeg_oppervlakte_kasten_toe_aan_ruimte(ruimte: EenhedenRuimte) -> str:
         TypeError: Als de ruimte ontbrekende informatie heeft, zoals oppervlakte of detailsoort.
     """
     if ruimte.detail_soort is None or ruimte.detail_soort.code is None:
-        error_msg = f"Ruimte {ruimte.id} heeft geen detailsoort en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
-        logger.error(error_msg)
+        error_msg = f"ruimte {ruimte.id} heeft geen detailsoort en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
         raise TypeError(error_msg)
 
     if ruimte.oppervlakte is None:
-        error_msg = f"Ruimte {ruimte.id} heeft geen oppervlakte en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
-        logger.error(error_msg)
+        error_msg = f"ruimte {ruimte.id} heeft geen oppervlakte en kan daardoor niet gewaardeerd worden voor {Woningwaarderingstelsel.zelfstandige_woonruimten}"
         raise TypeError(error_msg)
 
     criterium_naam = ruimte.naam or "Naamloze ruimte"

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from loguru import logger
+
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
 from woningwaardering.vera.bvg.generated import (
@@ -19,6 +21,8 @@ class Verwarming(Stelselgroep):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     verwarming = Verwarming()
     with open("./tests/data/input/generiek/37101000032.json", "r+") as file:
         eenheid = EenhedenEenheid.model_validate_json(file.read())

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming_2024.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/verwarming/verwarming_2024.py
@@ -59,8 +59,7 @@ class Verwarming2024(Stelselgroepversie):
 
         for ruimte in eenheid.ruimten or []:
             if ruimte.detail_soort is None:
-                error_msg = f"Ruimte {ruimte.id} heeft geen detailsoort"
-                logger.error(error_msg)
+                error_msg = f"ruimte {ruimte.id} heeft geen detailsoort"
                 raise TypeError(error_msg)
 
             ruimtesoort = classificeer_ruimte(ruimte)
@@ -179,6 +178,8 @@ class Verwarming2024(Stelselgroepversie):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     file = open(
         "tests/data/input/zelfstandige_woonruimten/77795000000.json",
         "r+",

--- a/woningwaardering/stelsels/zelfstandige_woonruimten/zelfstandige_woonruimten.py
+++ b/woningwaardering/stelsels/zelfstandige_woonruimten/zelfstandige_woonruimten.py
@@ -1,5 +1,7 @@
 from datetime import date
 
+from loguru import logger
+
 
 from woningwaardering.stelsels.stelsel import Stelsel
 from woningwaardering.stelsels import utils
@@ -20,6 +22,8 @@ class ZelfstandigeWoonruimten(Stelsel):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     zelfstandige_woonruimten = ZelfstandigeWoonruimten()
     file = open(
         "./tests/data/input/zelfstandige_woonruimten/41123000005.json",

--- a/woningwaardering/templates/stelsels/stelsel/stelsel.py.j2
+++ b/woningwaardering/templates/stelsels/stelsel/stelsel.py.j2
@@ -1,5 +1,6 @@
 from datetime import date
 
+from loguru import logger
 
 from woningwaardering.stelsels.stelsel import Stelsel
 from woningwaardering.stelsels import utils
@@ -20,6 +21,8 @@ class {{ className }}(Stelsel):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     {{ stelsel.name }} = {{ className }}()
     file = open(
         "./tests/data/input/generiek/37101000032.json",

--- a/woningwaardering/templates/stelsels/stelsel/stelselgroep/stelselgroep.py.j2
+++ b/woningwaardering/templates/stelsels/stelsel/stelselgroep/stelselgroep.py.j2
@@ -1,5 +1,7 @@
 from datetime import date
 
+from loguru import logger
+
 from woningwaardering.stelsels import utils
 from woningwaardering.stelsels.stelselgroep import Stelselgroep
 from woningwaardering.vera.bvg.generated import (
@@ -19,6 +21,8 @@ class {{ className }}(Stelselgroep):
 
 
 if __name__ == "__main__":
+    logger.enable("woningwaardering")
+
     {{ stelselgroep.name }} = {{ className }}()
     with open(
         "./tests/data/input/generiek/37101000032.json", "r+"

--- a/woningwaardering/vera/referentiedata/aanbiedingdetailstatus.py
+++ b/woningwaardering/vera/referentiedata/aanbiedingdetailstatus.py
@@ -292,7 +292,7 @@ class Aanbiedingdetailstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/aanbiedingstatus.py
+++ b/woningwaardering/vera/referentiedata/aanbiedingstatus.py
@@ -38,7 +38,7 @@ class Aanbiedingstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/aanvullendedoelgroep.py
+++ b/woningwaardering/vera/referentiedata/aanvullendedoelgroep.py
@@ -126,7 +126,7 @@ class Aanvullendedoelgroep(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/accountstatus.py
+++ b/woningwaardering/vera/referentiedata/accountstatus.py
@@ -39,7 +39,7 @@ class Accountstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/adressoort.py
+++ b/woningwaardering/vera/referentiedata/adressoort.py
@@ -30,7 +30,7 @@ class Adressoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/afletterstatus.py
+++ b/woningwaardering/vera/referentiedata/afletterstatus.py
@@ -38,7 +38,7 @@ class Afletterstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/afrekenwijzesoort.py
+++ b/woningwaardering/vera/referentiedata/afrekenwijzesoort.py
@@ -50,7 +50,7 @@ class Afrekenwijzesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/afspraakstatus.py
+++ b/woningwaardering/vera/referentiedata/afspraakstatus.py
@@ -39,7 +39,7 @@ class Afspraakstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/afspraakverzoeksoort.py
+++ b/woningwaardering/vera/referentiedata/afspraakverzoeksoort.py
@@ -24,7 +24,7 @@ class Afspraakverzoeksoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/afwezigheidsoort.py
+++ b/woningwaardering/vera/referentiedata/afwezigheidsoort.py
@@ -61,7 +61,7 @@ class Afwezigheidsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/aktesoort.py
+++ b/woningwaardering/vera/referentiedata/aktesoort.py
@@ -22,7 +22,7 @@ class Aktesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/authentiekgegevenbron.py
+++ b/woningwaardering/vera/referentiedata/authentiekgegevenbron.py
@@ -62,7 +62,7 @@ class Authentiekgegevenbron(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/authentiekgegevensoort.py
+++ b/woningwaardering/vera/referentiedata/authentiekgegevensoort.py
@@ -70,7 +70,7 @@ class Authentiekgegevensoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/authentiekgegevenstatus.py
+++ b/woningwaardering/vera/referentiedata/authentiekgegevenstatus.py
@@ -22,7 +22,7 @@ class Authentiekgegevenstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/bedrijfsoort.py
+++ b/woningwaardering/vera/referentiedata/bedrijfsoort.py
@@ -85,7 +85,7 @@ class Bedrijfsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/begrotingversie.py
+++ b/woningwaardering/vera/referentiedata/begrotingversie.py
@@ -31,7 +31,7 @@ class Begrotingversie(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/bestemming.py
+++ b/woningwaardering/vera/referentiedata/bestemming.py
@@ -30,7 +30,7 @@ class Bestemming(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/betaalgegevensoort.py
+++ b/woningwaardering/vera/referentiedata/betaalgegevensoort.py
@@ -42,7 +42,7 @@ class Betaalgegevensoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/betaalwijzedeelsoort.py
+++ b/woningwaardering/vera/referentiedata/betaalwijzedeelsoort.py
@@ -34,7 +34,7 @@ class Betaalwijzedeelsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/betaalwijzesoort.py
+++ b/woningwaardering/vera/referentiedata/betaalwijzesoort.py
@@ -24,7 +24,7 @@ class Betaalwijzesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/betalingsregelingeindereden.py
+++ b/woningwaardering/vera/referentiedata/betalingsregelingeindereden.py
@@ -39,7 +39,7 @@ class Betalingsregelingeindereden(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/betalingsregelingstatus.py
+++ b/woningwaardering/vera/referentiedata/betalingsregelingstatus.py
@@ -47,7 +47,7 @@ class Betalingsregelingstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/boekingdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/boekingdetailsoort.py
@@ -134,7 +134,7 @@ class Boekingdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/boekingsoort.py
+++ b/woningwaardering/vera/referentiedata/boekingsoort.py
@@ -92,7 +92,7 @@ class Boekingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/boekingstatus.py
+++ b/woningwaardering/vera/referentiedata/boekingstatus.py
@@ -30,7 +30,7 @@ class Boekingstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/boekjaarperiodesoort.py
+++ b/woningwaardering/vera/referentiedata/boekjaarperiodesoort.py
@@ -62,7 +62,7 @@ class Boekjaarperiodesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/boekjaarperiodestatus.py
+++ b/woningwaardering/vera/referentiedata/boekjaarperiodestatus.py
@@ -22,7 +22,7 @@ class Boekjaarperiodestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/boekjaarstatus.py
+++ b/woningwaardering/vera/referentiedata/boekjaarstatus.py
@@ -26,7 +26,7 @@ class Boekjaarstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/bouwkundigelementdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/bouwkundigelementdetailsoort.py
@@ -1179,7 +1179,7 @@ class Bouwkundigelementdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/bouwkundigelementplaatsing.py
+++ b/woningwaardering/vera/referentiedata/bouwkundigelementplaatsing.py
@@ -40,7 +40,7 @@ class Bouwkundigelementplaatsing(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/bouwkundigelementsoort.py
+++ b/woningwaardering/vera/referentiedata/bouwkundigelementsoort.py
@@ -26,7 +26,7 @@ class Bouwkundigelementsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/brandwerendheidscore.py
+++ b/woningwaardering/vera/referentiedata/brandwerendheidscore.py
@@ -86,7 +86,7 @@ class Brandwerendheidscore(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/btw.py
+++ b/woningwaardering/vera/referentiedata/btw.py
@@ -41,7 +41,7 @@ class Btw(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/btwaangiftestatus.py
+++ b/woningwaardering/vera/referentiedata/btwaangiftestatus.py
@@ -21,7 +21,7 @@ class Btwaangiftestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/burgerlijkestaat.py
+++ b/woningwaardering/vera/referentiedata/burgerlijkestaat.py
@@ -55,7 +55,7 @@ class Burgerlijkestaat(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/clustersoort.py
+++ b/woningwaardering/vera/referentiedata/clustersoort.py
@@ -87,7 +87,7 @@ class Clustersoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/collectiefobjectsoort.py
+++ b/woningwaardering/vera/referentiedata/collectiefobjectsoort.py
@@ -138,7 +138,7 @@ class Collectiefobjectsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/communicatiekanaal.py
+++ b/woningwaardering/vera/referentiedata/communicatiekanaal.py
@@ -51,7 +51,7 @@ class Communicatiekanaal(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/communicatierichting.py
+++ b/woningwaardering/vera/referentiedata/communicatierichting.py
@@ -16,7 +16,7 @@ class Communicatierichting(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/conditiescore.py
+++ b/woningwaardering/vera/referentiedata/conditiescore.py
@@ -56,7 +56,7 @@ class Conditiescore(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/contactgegevendetailsoort.py
+++ b/woningwaardering/vera/referentiedata/contactgegevendetailsoort.py
@@ -21,7 +21,7 @@ class Contactgegevendetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/contactgegevensoort.py
+++ b/woningwaardering/vera/referentiedata/contactgegevensoort.py
@@ -47,7 +47,7 @@ class Contactgegevensoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/contactgegevenstatus.py
+++ b/woningwaardering/vera/referentiedata/contactgegevenstatus.py
@@ -30,7 +30,7 @@ class Contactgegevenstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/contactgegevenvoorkeur.py
+++ b/woningwaardering/vera/referentiedata/contactgegevenvoorkeur.py
@@ -16,7 +16,7 @@ class Contactgegevenvoorkeur(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/crediteursoort.py
+++ b/woningwaardering/vera/referentiedata/crediteursoort.py
@@ -78,7 +78,7 @@ class Crediteursoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/crediteurstatus.py
+++ b/woningwaardering/vera/referentiedata/crediteurstatus.py
@@ -32,7 +32,7 @@ class Crediteurstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/dagdeel.py
+++ b/woningwaardering/vera/referentiedata/dagdeel.py
@@ -30,7 +30,7 @@ class Dagdeel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/debiteursoort.py
+++ b/woningwaardering/vera/referentiedata/debiteursoort.py
@@ -26,7 +26,7 @@ class Debiteursoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/debiteurstatus.py
+++ b/woningwaardering/vera/referentiedata/debiteurstatus.py
@@ -26,7 +26,7 @@ class Debiteurstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/defectlocatie.py
+++ b/woningwaardering/vera/referentiedata/defectlocatie.py
@@ -199,7 +199,7 @@ class Defectlocatie(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/defectoorzaak.py
+++ b/woningwaardering/vera/referentiedata/defectoorzaak.py
@@ -84,7 +84,7 @@ class Defectoorzaak(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/defectsoort.py
+++ b/woningwaardering/vera/referentiedata/defectsoort.py
@@ -350,7 +350,7 @@ class Defectsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/defectstatus.py
+++ b/woningwaardering/vera/referentiedata/defectstatus.py
@@ -16,7 +16,7 @@ class Defectstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/doelgroep.py
+++ b/woningwaardering/vera/referentiedata/doelgroep.py
@@ -79,7 +79,7 @@ class Doelgroep(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidcriteriasoort.py
+++ b/woningwaardering/vera/referentiedata/eenheidcriteriasoort.py
@@ -24,7 +24,7 @@ class Eenheidcriteriasoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidcriteriumdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/eenheidcriteriumdetailsoort.py
@@ -271,7 +271,7 @@ class Eenheidcriteriumdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidcriteriumsoort.py
+++ b/woningwaardering/vera/referentiedata/eenheidcriteriumsoort.py
@@ -41,7 +41,7 @@ class Eenheidcriteriumsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidcriteriumtoepassing.py
+++ b/woningwaardering/vera/referentiedata/eenheidcriteriumtoepassing.py
@@ -24,7 +24,7 @@ class Eenheidcriteriumtoepassing(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheiddetailsoort.py
+++ b/woningwaardering/vera/referentiedata/eenheiddetailsoort.py
@@ -1026,7 +1026,7 @@ class Eenheiddetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheiddetailstatus.py
+++ b/woningwaardering/vera/referentiedata/eenheiddetailstatus.py
@@ -201,7 +201,7 @@ class Eenheiddetailstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidenergievoorziening.py
+++ b/woningwaardering/vera/referentiedata/eenheidenergievoorziening.py
@@ -45,7 +45,7 @@ class Eenheidenergievoorziening(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidinterieur.py
+++ b/woningwaardering/vera/referentiedata/eenheidinterieur.py
@@ -44,7 +44,7 @@ class Eenheidinterieur(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidisolatie.py
+++ b/woningwaardering/vera/referentiedata/eenheidisolatie.py
@@ -47,7 +47,7 @@ class Eenheidisolatie(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidklimaatbeheersing.py
+++ b/woningwaardering/vera/referentiedata/eenheidklimaatbeheersing.py
@@ -201,7 +201,7 @@ class Eenheidklimaatbeheersing(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidklimaatbeheersingsoort.py
+++ b/woningwaardering/vera/referentiedata/eenheidklimaatbeheersingsoort.py
@@ -16,7 +16,7 @@ class Eenheidklimaatbeheersingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidligging.py
+++ b/woningwaardering/vera/referentiedata/eenheidligging.py
@@ -76,7 +76,7 @@ class Eenheidligging(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidmonument.py
+++ b/woningwaardering/vera/referentiedata/eenheidmonument.py
@@ -76,7 +76,7 @@ class Eenheidmonument(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidprijsconditie.py
+++ b/woningwaardering/vera/referentiedata/eenheidprijsconditie.py
@@ -49,7 +49,7 @@ class Eenheidprijsconditie(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidsanitair.py
+++ b/woningwaardering/vera/referentiedata/eenheidsanitair.py
@@ -21,7 +21,7 @@ class Eenheidsanitair(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidsoort.py
+++ b/woningwaardering/vera/referentiedata/eenheidsoort.py
@@ -69,7 +69,7 @@ class Eenheidsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eenheidstatus.py
+++ b/woningwaardering/vera/referentiedata/eenheidstatus.py
@@ -54,7 +54,7 @@ class Eenheidstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eindedetailreden.py
+++ b/woningwaardering/vera/referentiedata/eindedetailreden.py
@@ -117,7 +117,7 @@ class Eindedetailreden(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/eindereden.py
+++ b/woningwaardering/vera/referentiedata/eindereden.py
@@ -35,7 +35,7 @@ class Eindereden(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/energielabel.py
+++ b/woningwaardering/vera/referentiedata/energielabel.py
@@ -61,7 +61,7 @@ class Energielabel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/energieprestatiesoort.py
+++ b/woningwaardering/vera/referentiedata/energieprestatiesoort.py
@@ -78,7 +78,7 @@ class Energieprestatiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/energieprestatiestatus.py
+++ b/woningwaardering/vera/referentiedata/energieprestatiestatus.py
@@ -24,7 +24,7 @@ class Energieprestatiestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/energieprestatievergoedingsoort.py
+++ b/woningwaardering/vera/referentiedata/energieprestatievergoedingsoort.py
@@ -28,7 +28,7 @@ class Energieprestatievergoedingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/externeincassosoort.py
+++ b/woningwaardering/vera/referentiedata/externeincassosoort.py
@@ -16,7 +16,7 @@ class Externeincassosoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/externeincassostatus.py
+++ b/woningwaardering/vera/referentiedata/externeincassostatus.py
@@ -21,7 +21,7 @@ class Externeincassostatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/factuurbetaalwijze.py
+++ b/woningwaardering/vera/referentiedata/factuurbetaalwijze.py
@@ -31,7 +31,7 @@ class Factuurbetaalwijze(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/factuursoort.py
+++ b/woningwaardering/vera/referentiedata/factuursoort.py
@@ -38,7 +38,7 @@ class Factuursoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/gebeurtenissoort.py
+++ b/woningwaardering/vera/referentiedata/gebeurtenissoort.py
@@ -134,7 +134,7 @@ class Gebeurtenissoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/geometriesoort.py
+++ b/woningwaardering/vera/referentiedata/geometriesoort.py
@@ -22,7 +22,7 @@ class Geometriesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/geslacht.py
+++ b/woningwaardering/vera/referentiedata/geslacht.py
@@ -30,7 +30,7 @@ class Geslacht(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/grootboekmutatieherkomst.py
+++ b/woningwaardering/vera/referentiedata/grootboekmutatieherkomst.py
@@ -117,7 +117,7 @@ class Grootboekmutatieherkomst(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/grootboekrekeningsoort.py
+++ b/woningwaardering/vera/referentiedata/grootboekrekeningsoort.py
@@ -11,7 +11,7 @@ class Grootboekrekeningsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/grootboekrekeningstatus.py
+++ b/woningwaardering/vera/referentiedata/grootboekrekeningstatus.py
@@ -21,7 +21,7 @@ class Grootboekrekeningstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/huurgeschilsoort.py
+++ b/woningwaardering/vera/referentiedata/huurgeschilsoort.py
@@ -47,7 +47,7 @@ class Huurgeschilsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/huurgeschilstatus.py
+++ b/woningwaardering/vera/referentiedata/huurgeschilstatus.py
@@ -30,7 +30,7 @@ class Huurgeschilstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/huurklasse.py
+++ b/woningwaardering/vera/referentiedata/huurklasse.py
@@ -42,7 +42,7 @@ class Huurklasse(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/huuropzeggingstatus.py
+++ b/woningwaardering/vera/referentiedata/huuropzeggingstatus.py
@@ -48,7 +48,7 @@ class Huuropzeggingstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/incassomoment.py
+++ b/woningwaardering/vera/referentiedata/incassomoment.py
@@ -263,7 +263,7 @@ class Incassomoment(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inexploitatiereden.py
+++ b/woningwaardering/vera/referentiedata/inexploitatiereden.py
@@ -91,7 +91,7 @@ class Inexploitatiereden(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/informatieobjectdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/informatieobjectdetailsoort.py
@@ -79,7 +79,7 @@ class Informatieobjectdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/informatieobjectsoort.py
+++ b/woningwaardering/vera/referentiedata/informatieobjectsoort.py
@@ -70,7 +70,7 @@ class Informatieobjectsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inkomensbron.py
+++ b/woningwaardering/vera/referentiedata/inkomensbron.py
@@ -26,7 +26,7 @@ class Inkomensbron(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inkomenssoort.py
+++ b/woningwaardering/vera/referentiedata/inkomenssoort.py
@@ -23,7 +23,7 @@ class Inkomenssoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inkomensverklaringsoort.py
+++ b/woningwaardering/vera/referentiedata/inkomensverklaringsoort.py
@@ -36,7 +36,7 @@ class Inkomensverklaringsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inkoopfactuurstatus.py
+++ b/woningwaardering/vera/referentiedata/inkoopfactuurstatus.py
@@ -102,7 +102,7 @@ class Inkoopfactuurstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inkoopopdrachtregelsoort.py
+++ b/woningwaardering/vera/referentiedata/inkoopopdrachtregelsoort.py
@@ -30,7 +30,7 @@ class Inkoopopdrachtregelsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inschrijvingherkomst.py
+++ b/woningwaardering/vera/referentiedata/inschrijvingherkomst.py
@@ -56,7 +56,7 @@ class Inschrijvingherkomst(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inspectierapportsoort.py
+++ b/woningwaardering/vera/referentiedata/inspectierapportsoort.py
@@ -39,7 +39,7 @@ class Inspectierapportsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/inspectierapportstatus.py
+++ b/woningwaardering/vera/referentiedata/inspectierapportstatus.py
@@ -31,7 +31,7 @@ class Inspectierapportstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/kandidaatdetailstatus.py
+++ b/woningwaardering/vera/referentiedata/kandidaatdetailstatus.py
@@ -138,7 +138,7 @@ class Kandidaatdetailstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/kandidaatstatus.py
+++ b/woningwaardering/vera/referentiedata/kandidaatstatus.py
@@ -62,7 +62,7 @@ class Kandidaatstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/kwaliteitsniveau.py
+++ b/woningwaardering/vera/referentiedata/kwaliteitsniveau.py
@@ -26,7 +26,7 @@ class Kwaliteitsniveau(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/leningaflosvorm.py
+++ b/woningwaardering/vera/referentiedata/leningaflosvorm.py
@@ -29,7 +29,7 @@ class Leningaflosvorm(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/leningdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/leningdetailsoort.py
@@ -43,7 +43,7 @@ class Leningdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/leningsoort.py
+++ b/woningwaardering/vera/referentiedata/leningsoort.py
@@ -16,7 +16,7 @@ class Leningsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/maatschappelijklabel.py
+++ b/woningwaardering/vera/referentiedata/maatschappelijklabel.py
@@ -39,7 +39,7 @@ class Maatschappelijklabel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/machtigingsoort.py
+++ b/woningwaardering/vera/referentiedata/machtigingsoort.py
@@ -16,7 +16,7 @@ class Machtigingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/materiaaldetailsoort.py
+++ b/woningwaardering/vera/referentiedata/materiaaldetailsoort.py
@@ -1803,7 +1803,7 @@ class Materiaaldetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/materiaalsoort.py
+++ b/woningwaardering/vera/referentiedata/materiaalsoort.py
@@ -81,7 +81,7 @@ class Materiaalsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/medewerkerrol.py
+++ b/woningwaardering/vera/referentiedata/medewerkerrol.py
@@ -21,7 +21,7 @@ class Medewerkerrol(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/medewerkersoort.py
+++ b/woningwaardering/vera/referentiedata/medewerkersoort.py
@@ -31,7 +31,7 @@ class Medewerkersoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/meeteenheid.py
+++ b/woningwaardering/vera/referentiedata/meeteenheid.py
@@ -77,7 +77,7 @@ class Meeteenheid(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudsbestedingsoort.py
+++ b/woningwaardering/vera/referentiedata/onderhoudsbestedingsoort.py
@@ -77,7 +77,7 @@ class Onderhoudsbestedingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudslabel.py
+++ b/woningwaardering/vera/referentiedata/onderhoudslabel.py
@@ -31,7 +31,7 @@ class Onderhoudslabel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudsoort.py
+++ b/woningwaardering/vera/referentiedata/onderhoudsoort.py
@@ -71,7 +71,7 @@ class Onderhoudsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudsorderstatus.py
+++ b/woningwaardering/vera/referentiedata/onderhoudsorderstatus.py
@@ -101,7 +101,7 @@ class Onderhoudsorderstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudspecialisme.py
+++ b/woningwaardering/vera/referentiedata/onderhoudspecialisme.py
@@ -299,7 +299,7 @@ class Onderhoudspecialisme(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudstaakdetailstatus.py
+++ b/woningwaardering/vera/referentiedata/onderhoudstaakdetailstatus.py
@@ -78,7 +78,7 @@ class Onderhoudstaakdetailstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudstaakstatus.py
+++ b/woningwaardering/vera/referentiedata/onderhoudstaakstatus.py
@@ -83,7 +83,7 @@ class Onderhoudstaakstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/onderhoudsverzoekstatus.py
+++ b/woningwaardering/vera/referentiedata/onderhoudsverzoekstatus.py
@@ -68,7 +68,7 @@ class Onderhoudsverzoekstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/opleidingsniveau.py
+++ b/woningwaardering/vera/referentiedata/opleidingsniveau.py
@@ -108,7 +108,7 @@ class Opleidingsniveau(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/oppervlaktesoort.py
+++ b/woningwaardering/vera/referentiedata/oppervlaktesoort.py
@@ -69,7 +69,7 @@ class Oppervlaktesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/opzegtermijn.py
+++ b/woningwaardering/vera/referentiedata/opzegtermijn.py
@@ -62,7 +62,7 @@ class Opzegtermijn(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/organisatievorm.py
+++ b/woningwaardering/vera/referentiedata/organisatievorm.py
@@ -159,7 +159,7 @@ class Organisatievorm(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/overeenkomstdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/overeenkomstdetailsoort.py
@@ -215,7 +215,7 @@ class Overeenkomstdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/overeenkomstkoppelingdetailstatus.py
+++ b/woningwaardering/vera/referentiedata/overeenkomstkoppelingdetailstatus.py
@@ -56,7 +56,7 @@ class Overeenkomstkoppelingdetailstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/overeenkomstkoppelingstatus.py
+++ b/woningwaardering/vera/referentiedata/overeenkomstkoppelingstatus.py
@@ -30,7 +30,7 @@ class Overeenkomstkoppelingstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/overeenkomstsoort.py
+++ b/woningwaardering/vera/referentiedata/overeenkomstsoort.py
@@ -83,7 +83,7 @@ class Overeenkomstsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/overeenkomststatus.py
+++ b/woningwaardering/vera/referentiedata/overeenkomststatus.py
@@ -90,7 +90,7 @@ class Overeenkomststatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/passendheiddetailsoort.py
+++ b/woningwaardering/vera/referentiedata/passendheiddetailsoort.py
@@ -34,7 +34,7 @@ class Passendheiddetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/passendheidssoort.py
+++ b/woningwaardering/vera/referentiedata/passendheidssoort.py
@@ -34,7 +34,7 @@ class Passendheidssoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/prestatieafspraak.py
+++ b/woningwaardering/vera/referentiedata/prestatieafspraak.py
@@ -16,7 +16,7 @@ class Prestatieafspraak(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/prijsaanpassingsoort.py
+++ b/woningwaardering/vera/referentiedata/prijsaanpassingsoort.py
@@ -16,7 +16,7 @@ class Prijsaanpassingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/prijscomponentdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/prijscomponentdetailsoort.py
@@ -607,7 +607,7 @@ class Prijscomponentdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/prijscomponentsoort.py
+++ b/woningwaardering/vera/referentiedata/prijscomponentsoort.py
@@ -80,7 +80,7 @@ class Prijscomponentsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/prijscomponentsubsidiesoort.py
+++ b/woningwaardering/vera/referentiedata/prijscomponentsubsidiesoort.py
@@ -28,7 +28,7 @@ class Prijscomponentsubsidiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/prijscomponentwijzigingsreden.py
+++ b/woningwaardering/vera/referentiedata/prijscomponentwijzigingsreden.py
@@ -46,7 +46,7 @@ class Prijscomponentwijzigingsreden(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/projectbudgetregelregelsoort.py
+++ b/woningwaardering/vera/referentiedata/projectbudgetregelregelsoort.py
@@ -31,7 +31,7 @@ class Projectbudgetregelregelsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/projectbudgetregelsoort.py
+++ b/woningwaardering/vera/referentiedata/projectbudgetregelsoort.py
@@ -22,7 +22,7 @@ class Projectbudgetregelsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/projectbudgetregelstatus.py
+++ b/woningwaardering/vera/referentiedata/projectbudgetregelstatus.py
@@ -41,7 +41,7 @@ class Projectbudgetregelstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/projectfasebesluitstatus.py
+++ b/woningwaardering/vera/referentiedata/projectfasebesluitstatus.py
@@ -46,7 +46,7 @@ class Projectfasebesluitstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/projectsoort.py
+++ b/woningwaardering/vera/referentiedata/projectsoort.py
@@ -103,7 +103,7 @@ class Projectsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/projectstatus.py
+++ b/woningwaardering/vera/referentiedata/projectstatus.py
@@ -22,7 +22,7 @@ class Projectstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/provincie.py
+++ b/woningwaardering/vera/referentiedata/provincie.py
@@ -70,7 +70,7 @@ class Provincie(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/publicatiedetailmodel.py
+++ b/woningwaardering/vera/referentiedata/publicatiedetailmodel.py
@@ -58,7 +58,7 @@ class Publicatiedetailmodel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/publicatiedetailstatus.py
+++ b/woningwaardering/vera/referentiedata/publicatiedetailstatus.py
@@ -150,7 +150,7 @@ class Publicatiedetailstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/publicatieintakevorm.py
+++ b/woningwaardering/vera/referentiedata/publicatieintakevorm.py
@@ -55,7 +55,7 @@ class Publicatieintakevorm(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/publicatiemodel.py
+++ b/woningwaardering/vera/referentiedata/publicatiemodel.py
@@ -72,7 +72,7 @@ class Publicatiemodel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/publicatiestatus.py
+++ b/woningwaardering/vera/referentiedata/publicatiestatus.py
@@ -54,7 +54,7 @@ class Publicatiestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/puntenberekeningsoort.py
+++ b/woningwaardering/vera/referentiedata/puntenberekeningsoort.py
@@ -34,7 +34,7 @@ class Puntenberekeningsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/puntenmutatiesoort.py
+++ b/woningwaardering/vera/referentiedata/puntenmutatiesoort.py
@@ -110,7 +110,7 @@ class Puntenmutatiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/reclamatiesoort.py
+++ b/woningwaardering/vera/referentiedata/reclamatiesoort.py
@@ -23,7 +23,7 @@ class Reclamatiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/reclamatiestatus.py
+++ b/woningwaardering/vera/referentiedata/reclamatiestatus.py
@@ -46,7 +46,7 @@ class Reclamatiestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/redenontbinding.py
+++ b/woningwaardering/vera/referentiedata/redenontbinding.py
@@ -23,7 +23,7 @@ class Redenontbinding(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/redenopzegging.py
+++ b/woningwaardering/vera/referentiedata/redenopzegging.py
@@ -65,7 +65,7 @@ class Redenopzegging(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/redenvernietiging.py
+++ b/woningwaardering/vera/referentiedata/redenvernietiging.py
@@ -40,7 +40,7 @@ class Redenvernietiging(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/regiesoort.py
+++ b/woningwaardering/vera/referentiedata/regiesoort.py
@@ -44,7 +44,7 @@ class Regiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/relatieadressoort.py
+++ b/woningwaardering/vera/referentiedata/relatieadressoort.py
@@ -34,7 +34,7 @@ class Relatieadressoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/relatiedetailsoort.py
+++ b/woningwaardering/vera/referentiedata/relatiedetailsoort.py
@@ -19,7 +19,7 @@ class Relatiedetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/relatierolsoort.py
+++ b/woningwaardering/vera/referentiedata/relatierolsoort.py
@@ -440,7 +440,7 @@ class Relatierolsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/relatiesoort.py
+++ b/woningwaardering/vera/referentiedata/relatiesoort.py
@@ -34,7 +34,7 @@ class Relatiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/relatiestatus.py
+++ b/woningwaardering/vera/referentiedata/relatiestatus.py
@@ -30,7 +30,7 @@ class Relatiestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/rentesoort.py
+++ b/woningwaardering/vera/referentiedata/rentesoort.py
@@ -16,7 +16,7 @@ class Rentesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/ruimtedetailsoort.py
+++ b/woningwaardering/vera/referentiedata/ruimtedetailsoort.py
@@ -535,7 +535,7 @@ class Ruimtedetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/ruimteligging.py
+++ b/woningwaardering/vera/referentiedata/ruimteligging.py
@@ -46,7 +46,7 @@ class Ruimteligging(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/ruimtesoort.py
+++ b/woningwaardering/vera/referentiedata/ruimtesoort.py
@@ -42,7 +42,7 @@ class Ruimtesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/sanctiesoort.py
+++ b/woningwaardering/vera/referentiedata/sanctiesoort.py
@@ -30,7 +30,7 @@ class Sanctiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/sanctiestatus.py
+++ b/woningwaardering/vera/referentiedata/sanctiestatus.py
@@ -30,7 +30,7 @@ class Sanctiestatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/signaleringdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/signaleringdetailsoort.py
@@ -123,7 +123,7 @@ class Signaleringdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/signaleringsoort.py
+++ b/woningwaardering/vera/referentiedata/signaleringsoort.py
@@ -26,7 +26,7 @@ class Signaleringsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/signaleringstatus.py
+++ b/woningwaardering/vera/referentiedata/signaleringstatus.py
@@ -21,7 +21,7 @@ class Signaleringstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/taal.py
+++ b/woningwaardering/vera/referentiedata/taal.py
@@ -36,7 +36,7 @@ class Taal(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/toegankelijkheidslabel.py
+++ b/woningwaardering/vera/referentiedata/toegankelijkheidslabel.py
@@ -58,7 +58,7 @@ class Toegankelijkheidslabel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/uitexploitatiereden.py
+++ b/woningwaardering/vera/referentiedata/uitexploitatiereden.py
@@ -110,7 +110,7 @@ class Uitexploitatiereden(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/uitvoerendesoort.py
+++ b/woningwaardering/vera/referentiedata/uitvoerendesoort.py
@@ -22,7 +22,7 @@ class Uitvoerendesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/verantwoordingconsolidatie.py
+++ b/woningwaardering/vera/referentiedata/verantwoordingconsolidatie.py
@@ -23,7 +23,7 @@ class Verantwoordingconsolidatie(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/verantwoordingregime.py
+++ b/woningwaardering/vera/referentiedata/verantwoordingregime.py
@@ -42,7 +42,7 @@ class Verantwoordingregime(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/verbijzonderingsoort.py
+++ b/woningwaardering/vera/referentiedata/verbijzonderingsoort.py
@@ -106,7 +106,7 @@ class Verbijzonderingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/verbijzonderingstatus.py
+++ b/woningwaardering/vera/referentiedata/verbijzonderingstatus.py
@@ -21,7 +21,7 @@ class Verbijzonderingstatus(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/verrekeningsoort.py
+++ b/woningwaardering/vera/referentiedata/verrekeningsoort.py
@@ -22,7 +22,7 @@ class Verrekeningsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/vertrouwelijkheid.py
+++ b/woningwaardering/vera/referentiedata/vertrouwelijkheid.py
@@ -40,7 +40,7 @@ class Vertrouwelijkheid(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/voorrangdetailsoort.py
+++ b/woningwaardering/vera/referentiedata/voorrangdetailsoort.py
@@ -259,7 +259,7 @@ class Voorrangdetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/voorrangsoort.py
+++ b/woningwaardering/vera/referentiedata/voorrangsoort.py
@@ -41,7 +41,7 @@ class Voorrangsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/vragenlijstregelherkomst.py
+++ b/woningwaardering/vera/referentiedata/vragenlijstregelherkomst.py
@@ -30,7 +30,7 @@ class Vragenlijstregelherkomst(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/woningwaarderingstelsel.py
+++ b/woningwaardering/vera/referentiedata/woningwaarderingstelsel.py
@@ -42,7 +42,7 @@ class Woningwaarderingstelsel(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/woningwaarderingstelselgroep.py
+++ b/woningwaardering/vera/referentiedata/woningwaarderingstelselgroep.py
@@ -472,7 +472,7 @@ class Woningwaarderingstelselgroep(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/woonsituatiesoort.py
+++ b/woningwaardering/vera/referentiedata/woonsituatiesoort.py
@@ -23,7 +23,7 @@ class Woonsituatiesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/woonvorm.py
+++ b/woningwaardering/vera/referentiedata/woonvorm.py
@@ -77,7 +77,7 @@ class Woonvorm(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/zaakobjectsoort.py
+++ b/woningwaardering/vera/referentiedata/zaakobjectsoort.py
@@ -31,7 +31,7 @@ class Zaakobjectsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/zaakrol.py
+++ b/woningwaardering/vera/referentiedata/zaakrol.py
@@ -77,7 +77,7 @@ class Zaakrol(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/zaakstatussoort.py
+++ b/woningwaardering/vera/referentiedata/zaakstatussoort.py
@@ -55,7 +55,7 @@ class Zaakstatussoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/zaaktypedetailsoort.py
+++ b/woningwaardering/vera/referentiedata/zaaktypedetailsoort.py
@@ -222,7 +222,7 @@ class Zaaktypedetailsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/zaaktypesoort.py
+++ b/woningwaardering/vera/referentiedata/zaaktypesoort.py
@@ -46,7 +46,7 @@ class Zaaktypesoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/referentiedata/zekerheidverpandingsoort.py
+++ b/woningwaardering/vera/referentiedata/zekerheidverpandingsoort.py
@@ -62,7 +62,7 @@ class Zekerheidverpandingsoort(Enum):
     @property
     def code(self) -> str:
         if self.value.code is None:
-            raise TypeError("De code van een Referentiedata object mag niet None zijn.")
+            raise TypeError("de code van een Referentiedata object mag niet None zijn")
         return self.value.code
 
     @property

--- a/woningwaardering/vera/utils.py
+++ b/woningwaardering/vera/utils.py
@@ -1,5 +1,3 @@
-from loguru import logger
-
 from woningwaardering.vera.bvg.generated import EenhedenRuimte
 from woningwaardering.vera.referentiedata import (
     Bouwkundigelementdetailsoort,
@@ -21,8 +19,7 @@ def badruimte_met_toilet(ruimte: EenhedenRuimte) -> bool:
         TypeError: Als de ruimte geen detailsoort heeft.
     """
     if ruimte.detail_soort is None:
-        error_msg = f"{ruimte.id}: ruimte.detail_soort is None"
-        logger.error(error_msg)
+        error_msg = f"ruimte.detail_soort is None voor {ruimte.id}"
         raise TypeError(error_msg)
     return (ruimte.detail_soort.code == Ruimtedetailsoort.badkamer_met_toilet.code) or (
         ruimte.detail_soort.code


### PR DESCRIPTION
Met deze PR worden exceptions alleen gelogged als ze unhandled zijn. Daarnaast is de logging output nu disabled wanneer de package als dependency wordt gebruikt. Gebruikers van de package kunnen logging enablen met:
```
logger.enable("woningwaardering")
```
Op alle plekken waar tot nu toe logging te zien was, zien we die nog steeds.

Exception messages starten nu met lower case en eindigen zonder punt. Dit is conform de meeste standaard Python exceptions.

Deze branch is gebaseerd op #30, die moet gereviewd en gemerged worden voordat deze PR gemerged wordt.