### PR TITLE
Chore/package publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -108,6 +108,7 @@ jobs:
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
           --generate-notes
+          --notes-start-tag $(gh release view --repo '${{ github.repository }}' --jq .tagName --json tagName)
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,5 @@
 name: Publish Python distribution
-
+run-name: Publish release ${{ github.ref_name }}
 on:
   push:
     tags:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -108,7 +108,6 @@ jobs:
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
           --generate-notes
-          --notes-start-tag $(gh release view --repo '${{ github.repository }}' --jq .tagName --json tagName)
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -107,6 +107,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
+          ${{ if github.ref_name =~ 'alpha|beta|rc' }}--prerelease{{ endif }}
           --generate-notes
           --notes-start-tag $(gh release view --repo '${{ github.repository }}' --jq .tagName --json tagName)
       - name: Upload artifact signatures to GitHub Release

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -107,7 +107,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          ${{ if github.ref_name =~ 'alpha|beta|rc' }}--prerelease{{ endif }}
+          ${{ (contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc')) && '--prerelease' || ''}}
           --generate-notes
           --notes-start-tag $(gh release view --repo '${{ github.repository }}' --jq .tagName --json tagName)
       - name: Upload artifact signatures to GitHub Release


### PR DESCRIPTION
Wijziging in de workflow voor het publiceren van packages:

- Voor de publicatie van een alpha, beta of rc release wordt in GitHub een prerelease aangemaakt.
- Om de release notes te genereren, wordt de laatste stable release als startpunt genomen, zodat niet telkens alle PR's in de release notes worden opgenomen. De release notes van prereleases bevatten wel alle PR's die zijn toegevoegd sinds de laatste stable release.